### PR TITLE
Add latest option to start script

### DIFF
--- a/perceptia-one/README.md
+++ b/perceptia-one/README.md
@@ -132,6 +132,8 @@ Run: `.\locaStartExample.ps1 -BuildPOne`
 
 `-BuildPOne` (switch) will build the perceptiaone image using the local source, default is: false. To set true, include the switch
 
+`-Latest` (switch) will use the latest version of the perceptiaone image build for the develop branch, instead of a spcific version
+
 ### [Start with Docker Commands](#start-with-docker-commands)
 
 For directions to start the container locally using a script, see [Start Server Locally](#start-server-locally).

--- a/perceptia-one/localStartExample.ps1
+++ b/perceptia-one/localStartExample.ps1
@@ -3,7 +3,8 @@ Param (
     [String]$ApiServerPort = "4443",
     [String]$ApiServerScheme = "https",
     [String]$POnePortPublish = "4444",
-    [switch]$BuildPOne = $false
+    [switch]$BuildPOne = $false,
+    [switch]$Latest = $false
 
 )
 
@@ -32,7 +33,11 @@ if ($BuildPOne) {
     .
 } else {
     Write-Host "-BuildPOne option false, using prebuilt image from dockerhub"
-    Set-Variable -Name PERCEPTIAONE_IMAGE_AND_TAG -Value "uwthalesians/perceptiaone:0.0.1-build-latest-branch-develop"
+    Set-Variable -Name PONE_OPT -Value "163"
+    if ($Latest) {
+        Set-Variable -Name PONE_OPT -Value latest
+    }
+    Set-Variable -Name PERCEPTIAONE_IMAGE_AND_TAG -Value "uwthalesians/perceptiaone:0.0.1-build-${PONE_OPT}-branch-develop"
 }
 
 


### PR DESCRIPTION
Add option -Latest to localStartExample script so that when run without -BuildPOne option the image used will be the latest image built for the develop branch instead of a specific version.

No review necessary. 