### PR TITLE
Fix wrong env var used

### DIFF
--- a/perceptia-one/perceptia/src/components/constants.js
+++ b/perceptia-one/perceptia/src/components/constants.js
@@ -1,6 +1,6 @@
 
 let api_ref = process.env.REACT_APP_API_SERVER_SCHEME 
-            + "://" + process.env.REACT_APP_WEB_SERVER_HOST 
+            + "://" + process.env.REACT_APP_API_SERVER_HOST 
             + ":" + process.env.REACT_APP_API_SERVER_PORT;
 
 
@@ -13,10 +13,6 @@ export default {
 
     api: {
         url: api_ref
-    },
-
-    localhost: {
-        url: 'https://localhost:4443/api/v1/anyquiz/'
     }
 
 }


### PR DESCRIPTION
The REACT_APP_WEB_SERVER_HOST env var was used instead of the REACT_APP_API_SERVER_HOST env var when building the api_ref value. 