### PR TITLE
Feature: Update local start and dev deploy to build 443

### DIFF
--- a/infrastructure/kube/deploy/common/perceptia-web.yml
+++ b/infrastructure/kube/deploy/common/perceptia-web.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     label.perceptia.info/name: perceptiaone
     label.perceptia.info/instance: perceptiaone-1
-    label.perceptia.info/version: "0.1.1"
+    label.perceptia.info/version: "0.2.0"
     label.perceptia.info/managed-by: kubectl
     label.perceptia.info/component: server
     label.perceptia.info/type: frontend
@@ -21,7 +21,7 @@ spec:
         app: perceptiaone
         label.perceptia.info/name: perceptiaone
         label.perceptia.info/instance: perceptiaone-1
-        label.perceptia.info/version: "0.1.1"
+        label.perceptia.info/version: "0.2.0"
         label.perceptia.info/managed-by: kubectl
         label.perceptia.info/component: server
         label.perceptia.info/type: frontend
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: perceptiaone
-        image: uwthalesians/perceptiaone:0.1.1-build-358-branch-develop
+        image: uwthalesians/perceptiaone:0.2.0-build-443-branch-develop
         ports:
         - name: https
           containerPort: 443

--- a/infrastructure/kube/deploy/dev/perceptiaone.svc.yml
+++ b/infrastructure/kube/deploy/dev/perceptiaone.svc.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     label.perceptia.info/name: perceptiaone
     label.perceptia.info/instance: perceptiaone-1
-    label.perceptia.info/version: "0.0.1"
+    label.perceptia.info/version: "0.2.0"
     label.perceptia.info/managed-by: kubectl
     label.perceptia.info/component: server
     label.perceptia.info/type: frontend

--- a/perceptia-one/localStartExample.ps1
+++ b/perceptia-one/localStartExample.ps1
@@ -1,11 +1,11 @@
 Param (
     [switch]$Latest,
-    [string]$Build = "309",
+    [string]$Build = "443",
     [string]$Branch = "develop",
     [switch]$CurrentBranch,
 
     [switch]$BuildPOne,
-    [string]$POneVersion = "0.1.1",
+    [string]$POneVersion = "0.2.0",
     [String]$POnePortPublish = "4444",
 
     [String]$ApiServerHost = "localhost",

--- a/perceptia-one/perceptia/package-lock.json
+++ b/perceptia-one/perceptia/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "perceptia",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
# Overview

Updated the build number used for the localStartExample.ps1 script and the kubernetes dev deployment to build 443, which includes version 0.2.0 of the perceptiaone client. 